### PR TITLE
Replace connect-redis with connect-pg-simple

### DIFF
--- a/db/migrations/20190611_000000.app_private.tables.user_sessions-down.sql
+++ b/db/migrations/20190611_000000.app_private.tables.user_sessions-down.sql
@@ -1,0 +1,1 @@
+drop table app_private.user_sessions;

--- a/db/migrations/20190611_000000.app_private.tables.user_sessions-up.sql
+++ b/db/migrations/20190611_000000.app_private.tables.user_sessions-up.sql
@@ -1,0 +1,5 @@
+create table app_private.user_sessions (
+  sid varchar primary key,
+  sess jsonb not null,
+  expire timestamp(6) not null
+);

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "bfj": "^6.1.1",
     "case-sensitive-paths-webpack-plugin": "^2.2.0",
     "chalk": "^2.4.2",
-    "connect-redis": "^3.4.1",
+    "connect-pg-simple": "^5.0.0",
     "css-loader": "^2.1.1",
     "db-migrate": "^0.11.5",
     "db-migrate-pg": "^0.5.0",

--- a/scripts/setup
+++ b/scripts/setup
@@ -89,9 +89,6 @@ export CLIENT_PORT=5679
 export ROOT_DOMAIN="localhost:\$PORT"
 export ROOT_URL="http://\$ROOT_DOMAIN"
 
-# Our session store uses redis
-export REDIS_URL="redis://localhost/3"
-
 # To enable login with GitHub, create a GitHub application by visiting
 # https://github.com/settings/applications/new and then enter the Client
 # ID/Secret below

--- a/server/middleware/installSession.js
+++ b/server/middleware/installSession.js
@@ -1,5 +1,5 @@
 const session = require("express-session");
-const RedisStore = require("connect-redis")(session);
+const pgSession = require("connect-pg-simple")(session);
 
 const MILLISECOND = 1;
 const SECOND = 1000 * MILLISECOND;
@@ -12,6 +12,7 @@ const MAXIMUM_SESSION_DURATION_IN_MILLISECONDS =
   parseInt(process.env.MAXIMUM_SESSION_DURATION_IN_MILLISECONDS, 10) || 3 * DAY;
 
 module.exports = app => {
+  const pool = app.get("authPgPool");  // from `middleware.installDatabasePools`
   const sessionMiddleware = session({
     rolling: true,
     saveUninitialized: false,
@@ -19,11 +20,11 @@ module.exports = app => {
     cookie: {
       maxAge: MAXIMUM_SESSION_DURATION_IN_MILLISECONDS,
     },
-    store: process.env.REDIS_URL
-      ? new RedisStore({
-          url: process.env.REDIS_URL,
-        })
-      : undefined,
+    store: new pgSession({
+      pool,
+      schemaName: "app_private",
+      tableName: "user_sessions",
+    }),
     secret: SECRET,
   });
   app.use(sessionMiddleware);

--- a/server/utils.js
+++ b/server/utils.js
@@ -13,14 +13,5 @@ exports.sanitiseEnv = () => {
       );
     }
   });
-  const recommendedEnvvars = {
-    REDIS_URL: "without this, sessions will reset when the server restarts",
-  };
-  Object.entries(recommendedEnvvars).forEach(([envvar, reason]) => {
-    if (!process.env[envvar]) {
-      console.warn(`WARNING: Could not find process.env.${envvar} - ${reason}`);
-    }
-  });
-
   process.env.NODE_ENV = process.env.NODE_ENV || "development";
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2902,13 +2902,12 @@ connect-history-api-fallback@^1.6.0:
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
   integrity sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==
 
-connect-redis@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/connect-redis/-/connect-redis-3.4.1.tgz#0623af46182232457fefbc7d4f552d87d35b3d20"
-  integrity sha512-oXNcpLg/PJ6G4gbhyGwrQK9mUQTKYa2aEnOH9kWIxbNUjIFPqUmzz75RdLp5JTPSjrBVcz+9ll4sSxfvlW0ZLA==
+connect-pg-simple@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/connect-pg-simple/-/connect-pg-simple-5.0.0.tgz#f0304a1ee4e1e1a69e7783123cbcbf68d2155a19"
+  integrity sha512-WZ7xkN+qe5bbDLgZ1L9GxnSbr155cJHmfNRzVR5hBvqio7Pg/vuH7Cf8lPUSFClQjtybYSejUqyO54sYt4cg+w==
   dependencies:
-    debug "^4.1.1"
-    redis "^2.8.0"
+    pg "^7.4.3"
 
 console-browserify@^1.1.0:
   version "1.1.0"
@@ -3738,11 +3737,6 @@ dotenv@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-7.0.0.tgz#a2be3cd52736673206e8a85fb5210eea29628e7c"
   integrity sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==
-
-double-ended-queue@^2.1.0-0:
-  version "2.1.0-0"
-  resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
-  integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -7943,10 +7937,10 @@ pg-types@~2.0.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-"pg@>=6.1.0 <8", pg@^7.10.0, pg@^7.8.0, pg@^7.8.1:
-  version "7.10.0"
-  resolved "https://registry.yarnpkg.com/pg/-/pg-7.10.0.tgz#2a359ee29ed1971344ac7f44317a9d1bcd80a8ff"
-  integrity sha512-aE6FZomsyn3OeGv1oM50v7Xu5zR75c15LXdOCwA9GGrfjXsQjzwYpbcTS6OwEMhYfZQS6m/FVU/ilPLiPzJDCw==
+"pg@>=6.1.0 <8", pg@^7.4.3, pg@^7.10.0, pg@^7.8.0, pg@^7.8.1:
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-7.11.0.tgz#a8b9ae9cf19199b7952b72957573d0a9c5e67c0c"
+  integrity sha512-YO4V7vCmEMGoF390LJaFaohWNKaA2ayoQOEZmiHVcAUF+YsRThpf/TaKCgSvsSE7cDm37Q/Cy3Gz41xiX/XjTw==
   dependencies:
     buffer-writer "2.0.0"
     packet-reader "1.0.0"
@@ -9268,25 +9262,6 @@ recursive-readdir@2.2.2:
   integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
   dependencies:
     minimatch "3.0.4"
-
-redis-commands@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.4.0.tgz#52f9cf99153efcce56a8f86af986bd04e988602f"
-  integrity sha512-cu8EF+MtkwI4DLIT0x9P8qNTLFhQD4jLfxLR0cCNkeGzs87FN6879JOJwNQR/1zD7aSYNbU0hgsV9zGY71Itvw==
-
-redis-parser@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
-  integrity sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=
-
-redis@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/redis/-/redis-2.8.0.tgz#202288e3f58c49f6079d97af7a10e1303ae14b02"
-  integrity sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==
-  dependencies:
-    double-ended-queue "^2.1.0-0"
-    redis-commands "^1.2.0"
-    redis-parser "^2.6.0"
 
 regenerate-unicode-properties@^8.0.2:
   version "8.0.2"


### PR DESCRIPTION
[`connect-pg-simple`](https://github.com/voxpelli/node-connect-pg-simple) allows you to maintain user session information in Postgres, instead of Redis. Since Postgres can do this, and we aren't using Redis for anything else, I figured it makes the most sense to use Postgres for _everything_, since that seems to be the PostGraphile philosophy. :smile: