### PR TITLE
Verify email and reset password flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The project is split into the following folders:
 - `/data` - generated data, such as the GraphQL and database schema dumps
 - `/client` - everything related to the web browser: the react components, routes, etc
 - `/server` - everything related to running the server: the middlewares, PostGraphile configuration, SSR, integration tests, etc
+- `/tasks` - background tasks run by [Graphile Worker](https://github.com/graphile/worker)
 
 We currently use a root-level `package.json` between all of them. In future we
 might take a monorepo approach using yarn workspaces, but for now we figured
@@ -78,6 +79,7 @@ We use the following tools to make our life easier
 - Prettier for consistent code formatting
 - Express.js to implement our server
 - db-migrate for performing migrations
+- graphile-worker for running background tasks
 
 ## Getting Started
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -7,6 +7,8 @@ import HomePage from "./components/HomePage";
 import LoginPage from "./components/LoginPage";
 import RegisterPage from "./components/RegisterPage";
 import VerifyUserEmailPage from "./components/VerifyUserEmailPage";
+import ForgotPasswordPage from "./components/ForgotPasswordPage";
+import ResetPasswordPage from "./components/ResetPasswordPage";
 import NotFoundPage from "./components/NotFoundPage";
 
 class App extends Component {
@@ -17,6 +19,8 @@ class App extends Component {
         <GraphQLRoute path="/login" exact component={LoginPage} />
         <GraphQLRoute path="/register" exact component={RegisterPage} />
         <GraphQLRoute path="/verify-email/:token" exact component={VerifyUserEmailPage} />
+        <GraphQLRoute path="/forgot-password" exact component={ForgotPasswordPage} />
+        <GraphQLRoute path="/reset-password/:userId(\d+)/:token" exact component={ResetPasswordPage} />
 
         <Route component={NotFoundPage} />
       </Switch>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,6 +6,7 @@ import GraphQLRoute from "./GraphQLRoute";
 import HomePage from "./components/HomePage";
 import LoginPage from "./components/LoginPage";
 import RegisterPage from "./components/RegisterPage";
+import VerifyUserEmailPage from "./components/VerifyUserEmailPage";
 import NotFoundPage from "./components/NotFoundPage";
 
 class App extends Component {
@@ -15,6 +16,7 @@ class App extends Component {
         <GraphQLRoute path="/" exact component={HomePage} />
         <GraphQLRoute path="/login" exact component={LoginPage} />
         <GraphQLRoute path="/register" exact component={RegisterPage} />
+        <GraphQLRoute path="/verify-email/:token" exact component={VerifyUserEmailPage} />
 
         <Route component={NotFoundPage} />
       </Switch>

--- a/client/src/GraphQLRoute.js
+++ b/client/src/GraphQLRoute.js
@@ -3,7 +3,7 @@ import { Route } from "react-router-dom";
 import { Query } from "react-apollo";
 import gql from "graphql-tag";
 
-function queryGenFromComponent(Component) {
+export function queryGenFromComponent(Component) {
   const componentName = Component.displayName || Component.name;
   const fragment = Component.QueryFragment;
   if (!fragment) {
@@ -26,7 +26,7 @@ function queryGenFromComponent(Component) {
 }
 
 export default class GraphQLRoute extends React.Component {
-  renderComponent = () => {
+  renderComponent = (routerProps) => {
     const {
       component: Component,
       variables,
@@ -36,7 +36,7 @@ export default class GraphQLRoute extends React.Component {
       typeof queryGen === "function" ? queryGen(this.props) : queryGen;
     return (
       <Query query={query} variables={variables}>
-        {result => <Component {...result} />}
+        {result => <Component {...result} {...routerProps} />}
       </Query>
     );
   };

--- a/client/src/apolloClient.js
+++ b/client/src/apolloClient.js
@@ -10,7 +10,7 @@ export function makeClient() {
   });
 
   const logoutOn401ErrorLink = onError(({ networkError }) => {
-    if (networkError.status === 401) {
+    if (networkError && networkError.status === 401) {
       // Logout
     }
   });

--- a/client/src/components/ForgotPasswordPage.js
+++ b/client/src/components/ForgotPasswordPage.js
@@ -1,0 +1,116 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Redirect, Link } from "react-router-dom";
+import gql from "graphql-tag";
+import { Mutation } from "react-apollo";
+import { queryGenFromComponent } from "../GraphQLRoute";
+import HomePage from "./HomePage";
+import LoadingPage from "./LoadingPage";
+import ErrorPage from "./ErrorPage";
+import Layout from "./Layout";
+import "./form-table.css";
+
+const FORGOT_PASSWORD = gql`
+  mutation ForgotPassword($email: String!) {
+    forgotPassword(input: { email: $email }) {
+      success
+    }
+  }
+`;
+
+export default class ForgotPasswordPage extends React.Component {
+  static QueryFragment = gql`
+    fragment ForgotPasswordPage_QueryFragment on Query {
+      currentUser {
+        nodeId
+      }
+    }
+  `;
+
+  static propTypes = {
+    history: PropTypes.object.isRequired,
+  };
+
+  state = {
+    email: "",
+    error: null,
+    submitting: false,
+  };
+
+  handleEmailChange = e => {
+    this.setState({ email: e.target.value, error: null });
+  };
+
+  handleSubmitWith = forgotPassword => async e => {
+    e.preventDefault();
+    const { history } = this.props;
+    const { email } = this.state;
+    this.setState({ submitting: true });
+    try {
+      const { data } = await forgotPassword({ variables: { email } });
+      if (data.forgotPassword && data.forgotPassword.success) {
+        this.setState({ submitting: false, error: null });
+        history.push(this.getNext());
+      } else {
+        throw new Error("Failed to request password reset");
+      }
+    } catch (e) {
+      this.setState({
+        submitting: false,
+        error: "Failed to request password reset",
+      });
+    }
+  };
+
+  getNext() {
+    return "/";
+  }
+
+  render() {
+    const { data, loading, error } = this.props;
+    const { email, submitting } = this.state;
+    if (loading) return <LoadingPage />;
+    if (error) {
+      return (
+        <ErrorPage>
+          We failed talking to the server. Please reload the page.
+        </ErrorPage>
+      );
+    }
+    return (
+      <Layout>
+        <h1>Forgot Password</h1>
+        <p>Type in your email address, and we'll send you a link to reset your password.</p>
+        <Mutation
+          mutation={FORGOT_PASSWORD}
+        >
+          {forgotPassword => (
+            <form onSubmit={this.handleSubmitWith(forgotPassword)}>
+              <table className="form-table">
+                <tbody>
+                  <tr>
+                    <th>Email:</th>
+                    <td>
+                      <input
+                        type="text"
+                        value={email}
+                        onChange={this.handleEmailChange}
+                      />
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              {this.state.error ? <p>{this.state.error}</p> : null}
+              <button
+                type="submit"
+                disabled={!email || submitting }
+              >
+                Send password reset link
+              </button>
+            </form>
+          )}
+        </Mutation>
+      </Layout>
+    );
+  }
+}

--- a/client/src/components/HomePage.js
+++ b/client/src/components/HomePage.js
@@ -10,6 +10,7 @@ export default class HomePage extends React.Component {
       nodeId
       currentUser {
         nodeId
+        username
       }
     }
   `;
@@ -19,7 +20,14 @@ export default class HomePage extends React.Component {
     const status = (() => {
       if (loading) return "Loading...";
       if (error) return `Error: ${error.message}`;
-      if (data.currentUser) return <span><span className="wave">👋</span> Logged in</span>;
+      if (data.currentUser) {
+        return (
+          <span>
+            <span className="wave">👋</span>{" "}
+            Logged in as {data.currentUser.username}
+          </span>
+        );
+      }
       if (data.nodeId === "query") return "✅ Working";
       return "This should not happen";
     })();

--- a/client/src/components/LoginPage.js
+++ b/client/src/components/LoginPage.js
@@ -147,7 +147,14 @@ export default class LoginPage extends React.Component {
               >
                 Log in
               </button>
-              <Link to="/register">Don't have an account? Create one</Link>
+              <ul>
+                <li>
+                  <Link to="/register">Don't have an account? Create one</Link>
+                </li>
+                <li>
+                  <Link to="/forgot-password">Forgot your password? Reset it</Link>
+                </li>
+              </ul>
             </form>
           )}
         </Mutation>

--- a/client/src/components/RegisterPage.js
+++ b/client/src/components/RegisterPage.js
@@ -1,8 +1,11 @@
 import React from "react";
+import PropTypes from "prop-types";
 import pickBy from "lodash/pickBy";
 import { Redirect, Link } from "react-router-dom";
 import gql from "graphql-tag";
 import { Mutation } from "react-apollo";
+import { queryGenFromComponent } from "../GraphQLRoute";
+import HomePage from "./HomePage";
 import LoadingPage from "./LoadingPage";
 import ErrorPage from "./ErrorPage";
 import "./form-table.css";
@@ -26,9 +29,7 @@ const REGISTER = gql`
     ) {
       user {
         nodeId
-        id
         username
-        name
       }
     }
   }
@@ -42,6 +43,10 @@ export default class RegisterPage extends React.Component {
       }
     }
   `;
+
+  static propTypes = {
+    history: PropTypes.object.isRequired,
+  };
 
   state = {
     username: "",
@@ -80,6 +85,7 @@ export default class RegisterPage extends React.Component {
 
   handleSubmitWith = register => async e => {
     e.preventDefault();
+    const { history } = this.props;
     const { username, email, password, name, avatarUrl } = this.state;
     this.setState({ loggingIn: true });
     try {
@@ -93,7 +99,8 @@ export default class RegisterPage extends React.Component {
         }),
       });
       if (data.register && data.register.user) {
-        this.setState({ loggingIn: false, loggedInAs: data.register.user });
+        this.setState({ loggingIn: false, error: null });
+        history.push(this.getNext());
       } else {
         throw new Error("Registration failed");
       }
@@ -142,7 +149,25 @@ export default class RegisterPage extends React.Component {
     return (
       <div>
         <h3>Register</h3>
-        <Mutation mutation={REGISTER}>
+        <Mutation
+          mutation={REGISTER}
+          update={(
+            cache,
+            {
+              data: {
+                register: { user },
+              },
+            }
+          ) => {
+            const query = queryGenFromComponent(HomePage);
+            const cacheData = cache.readQuery({ query });
+            const data = {
+              ...cacheData,
+              currentUser: user,
+            };
+            cache.writeQuery({ query, data });
+          }}
+        >
           {register => (
             <form onSubmit={this.handleSubmitWith(register)}>
               <table className="form-table">

--- a/client/src/components/ResetPasswordPage.js
+++ b/client/src/components/ResetPasswordPage.js
@@ -1,0 +1,161 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Redirect, Link } from "react-router-dom";
+import gql from "graphql-tag";
+import { Mutation } from "react-apollo";
+import { queryGenFromComponent } from "../GraphQLRoute";
+import HomePage from "./HomePage";
+import LoadingPage from "./LoadingPage";
+import ErrorPage from "./ErrorPage";
+import Layout from "./Layout";
+import "./form-table.css";
+
+const RESET_PASSWORD = gql`
+  mutation ResetPassword(
+    $userId: Int!
+    $token: String!
+    $newPassword: String!
+  ) {
+    resetPassword(
+      input: { userId: $userId, token: $token, newPassword: $newPassword }
+    ) {
+      user {
+        nodeId
+        username
+      }
+    }
+  }
+`;
+
+export default class ResetPasswordPage extends React.Component {
+  static QueryFragment = gql`
+    fragment ResetPasswordPage_QueryFragment on Query {
+      currentUser {
+        nodeId
+      }
+    }
+  `;
+
+  static propTypes = {
+    history: PropTypes.object.isRequired,
+  };
+
+  static propTypes = {
+    loading: PropTypes.bool.isRequired,
+    history: PropTypes.object.isRequired,
+    match: PropTypes.shape({
+      params: PropTypes.shape({
+        userId: PropTypes.string.isRequired,
+        token: PropTypes.string.isRequired,
+      }).isRequired,
+    }).isRequired,
+  };
+
+  state = {
+    newPassword: "",
+    repeatNewPassword: "",
+    error: null,
+    settingPassword: false,
+  };
+
+  handleNewPasswordChange = e => {
+    this.setState({ newPassword: e.target.value, error: null });
+  };
+
+  handleRepeatNewPasswordChange = e => {
+    this.setState({ repeatNewPassword: e.target.value, error: null });
+  };
+
+  handleSubmitWith = resetPassword => async e => {
+    e.preventDefault();
+    const { history, match } = this.props;
+    const { newPassword } = this.state;
+    const { userId, token } = match.params;
+    this.setState({ settingPassword: true });
+    try {
+      const { data } = await resetPassword({
+        variables: { userId: parseInt(userId), token, newPassword },
+      });
+      if (data.resetPassword && data.resetPassword.user) {
+        this.setState({ settingPassword: false, error: null });
+        history.push(this.getNext());
+      } else {
+        throw new Error("Password reset failed");
+      }
+    } catch (e) {
+      this.setState({
+        settingPassword: false,
+        error: "Password reset failed",
+      });
+    }
+  };
+
+  getNext() {
+    return "/";
+  }
+
+  render() {
+    const { loading, error } = this.props;
+    const { newPassword, repeatNewPassword, settingPassword } = this.state;
+    if (loading) return <LoadingPage />;
+    if (error) {
+      return (
+        <ErrorPage>
+          We failed talking to the server. Please reload the page.
+        </ErrorPage>
+      );
+    }
+    const mismatchedPasswords = newPassword !== repeatNewPassword;
+    return (
+      <Layout>
+        <h1>Reset Password</h1>
+        <Mutation mutation={RESET_PASSWORD}>
+          {resetPassword => (
+            <form onSubmit={this.handleSubmitWith(resetPassword)}>
+              <table className="form-table">
+                <tbody>
+                  <tr>
+                    <th>New password:</th>
+                    <td>
+                      <input
+                        type="password"
+                        value={newPassword}
+                        onChange={this.handleNewPasswordChange}
+                      />
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Repeat new password:</th>
+                    <td>
+                      <input
+                        type="password"
+                        value={repeatNewPassword}
+                        onChange={this.handleRepeatNewPasswordChange}
+                      />
+                      {mismatchedPasswords && (
+                        <span className="error">Passwords must match</span>
+                      )}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              {this.state.error ? <p>{this.state.error}</p> : null}
+              <button
+                type="submit"
+                disabled={
+                  !newPassword ||
+                  !repeatNewPassword ||
+                  mismatchedPasswords ||
+                  settingPassword
+                }
+              >
+                Set Password
+              </button>
+              <Link to="/register">Don't have an account? Create one</Link>
+            </form>
+          )}
+        </Mutation>
+      </Layout>
+    );
+  }
+}

--- a/client/src/components/VerifyUserEmailPage.js
+++ b/client/src/components/VerifyUserEmailPage.js
@@ -1,0 +1,64 @@
+import React from "react";
+import PropTypes from "prop-types";
+import gql from "graphql-tag";
+import { compose, graphql } from "react-apollo";
+
+const VERIFY_USER_EMAIL = gql`
+  mutation VerifyUserEmail($token: String!) {
+    verifyUserEmail(input: { token: $token }) {
+      userEmail {
+        nodeId
+        isVerified
+      }
+    }
+  }
+`;
+
+class VerifyUserEmailPage extends React.Component {
+  static propTypes = {
+    verifyUserEmail: PropTypes.func.isRequired,
+    loading: PropTypes.bool.isRequired,
+    history: PropTypes.object.isRequired,
+    match: PropTypes.shape({
+      params: PropTypes.shape({
+        token: PropTypes.string.isRequired,
+      }).isRequired,
+    }).isRequired,
+  };
+
+  state = {
+    error: false,
+  };
+
+  componentDidMount() {
+    const { verifyUserEmail, history } = this.props;
+    verifyUserEmail()
+      .then(() => {
+        history.push("/");
+      })
+      .catch(() => {
+        this.setState({ error: true });
+      });
+  }
+
+  render() {
+    const { loading } = this.props;
+    const { error } = this.state;
+    if (loading) {
+      return <div>Verifying email...</div>;
+    }
+    if (error) {
+      return <div>whoops</div>;
+    }
+    return <div>email verified!</div>;
+  }
+}
+
+export default compose(
+  graphql(VERIFY_USER_EMAIL, {
+    name: "verifyUserEmail",
+    options: props => ({
+      variables: { token: props.match.params.token },
+    }),
+  })
+)(VerifyUserEmailPage);

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -516,7 +516,7 @@ input ResetPasswordInput {
   """
   clientMutationId: String
   newPassword: String!
-  resetToken: String!
+  token: String!
   userId: Int!
 }
 

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -411,6 +411,11 @@ type Mutation {
     """
     input: UpdateUserByUsernameInput!
   ): UpdateUserPayload
+
+  """
+  After you add an email address, you will receive an email with a verification
+  token. Give us the verification token to mark that email as verified!
+  """
   verifyUserEmail(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -815,10 +820,36 @@ enum UsersOrderBy {
   USERNAME_DESC
 }
 
+"""All input for the `verifyUserEmail` mutation."""
 input VerifyUserEmailInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
   token: String!
 }
 
+"""The output of our `verifyUserEmail` mutation."""
 type VerifyUserEmailPayload {
-  userEmail: UserEmail!
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `User` that is related to this `UserEmail`."""
+  user: User
+  userEmail: UserEmail
+
+  """An edge for our `UserEmail`. May be used by Relay 1."""
+  userEmailEdge(
+    """The method to use when ordering `UserEmail`."""
+    orderBy: [UserEmailsOrderBy!] = PRIMARY_KEY_ASC
+  ): UserEmailsEdge
 }

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -411,6 +411,12 @@ type Mutation {
     """
     input: UpdateUserByUsernameInput!
   ): UpdateUserPayload
+  verifyUserEmail(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: VerifyUserEmailInput!
+  ): VerifyUserEmailPayload
 }
 
 """An object with a globally unique `ID`."""
@@ -807,4 +813,12 @@ enum UsersOrderBy {
   PRIMARY_KEY_DESC
   USERNAME_ASC
   USERNAME_DESC
+}
+
+input VerifyUserEmailInput {
+  token: String!
+}
+
+type VerifyUserEmailPayload {
+  userEmail: UserEmail!
 }

--- a/data/schema.json
+++ b/data/schema.json
@@ -1706,6 +1706,33 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "verifyUserEmail",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": "The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "VerifyUserEmailInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "VerifyUserEmailPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -3314,6 +3341,58 @@
             }
           ],
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "VerifyUserEmailInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "token",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "VerifyUserEmailPayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "userEmail",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "UserEmail",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         },

--- a/data/schema.json
+++ b/data/schema.json
@@ -1709,7 +1709,7 @@
             },
             {
               "name": "verifyUserEmail",
-              "description": null,
+              "description": "After you add an email address, you will receive an email with a verification token. Give us the verification token to mark that email as verified!",
               "args": [
                 {
                   "name": "input",
@@ -3347,9 +3347,19 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "VerifyUserEmailInput",
-          "description": null,
+          "description": "All input for the `verifyUserEmail` mutation.",
           "fields": null,
           "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
             {
               "name": "token",
               "description": null,
@@ -3372,20 +3382,83 @@
         {
           "kind": "OBJECT",
           "name": "VerifyUserEmailPayload",
-          "description": null,
+          "description": "The output of our `verifyUserEmail` mutation.",
           "fields": [
+            {
+              "name": "clientMutationId",
+              "description": "The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "query",
+              "description": "Our root query field type. Allows us to run any query from our mutation payload.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Query",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "user",
+              "description": "Reads a single `User` that is related to this `UserEmail`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "userEmail",
               "description": null,
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "UserEmail",
-                  "ofType": null
+                "kind": "OBJECT",
+                "name": "UserEmail",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userEmailEdge",
+              "description": "An edge for our `UserEmail`. May be used by Relay 1.",
+              "args": [
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `UserEmail`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "UserEmailsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "PRIMARY_KEY_ASC"
                 }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "UserEmailsEdge",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/data/schema.json
+++ b/data/schema.json
@@ -2978,7 +2978,7 @@
               "defaultValue": null
             },
             {
-              "name": "resetToken",
+              "name": "token",
               "description": null,
               "type": {
                 "kind": "NON_NULL",

--- a/data/schema.sql
+++ b/data/schema.sql
@@ -458,8 +458,6 @@ CREATE FUNCTION app_private.tg_send_verification_email_for_user_email() RETURNS 
     LANGUAGE plpgsql
     SET search_path TO '$user', 'public'
     AS $$
-declare
-  v_verification_token text;
 begin
   -- Trigger email send
   perform graphile_worker.add_job(

--- a/data/schema.sql
+++ b/data/schema.sql
@@ -797,7 +797,7 @@ begin
   RETURNING * INTO v_user_email;
 
   if v_user_email is NULL THEN
-    raise exception 'verification token is invalid or expired' using errcode='INVALID';
+    raise exception 'verification token is invalid or expired' using errcode='INVLD';
   end if;
 
   return v_user_email;

--- a/db/migrations/.db-migrate/20190713000000-app_public__functions__verify_user_email.js
+++ b/db/migrations/.db-migrate/20190713000000-app_public__functions__verify_user_email.js
@@ -1,0 +1,2 @@
+/* This is boilerplate, you want the parent directory for the actual migrations */
+module.exports = require('../../scripts/migrate')("20190713_000000.app_public.functions.verify_user_email");

--- a/db/migrations/20181102_194915.app_private.user_secrets.create-up.sql
+++ b/db/migrations/20181102_194915.app_private.user_secrets.create-up.sql
@@ -1,6 +1,10 @@
 create table app_private.user_secrets (
   user_id int not null primary key references app_public.users on delete cascade,
-  password_hash text
+  password_hash text,
+  reset_password_token text,
+  reset_password_token_generated_at timestamptz,
+  first_failed_reset_password_attempt timestamptz,
+  reset_password_attempts int DEFAULT 0 NOT NULL
 );
 alter table app_private.user_secrets enable row level security;
 comment on table app_private.user_secrets is

--- a/db/migrations/20181102_200855.app_private.tables.user_email_secrets-down.sql
+++ b/db/migrations/20181102_200855.app_private.tables.user_email_secrets-down.sql
@@ -1,3 +1,5 @@
 drop trigger _500_insert_secrets on app_public.user_emails;
+drop trigger _900_send_verification_email on app_public.user_emails;
 drop function app_private.tg_user_email_secrets__insert_with_user_email();
+drop function app_private.tg_user_email_secrets__send_verification_email();
 drop table app_private.user_email_secrets;

--- a/db/migrations/20181102_200855.app_private.tables.user_email_secrets-up.sql
+++ b/db/migrations/20181102_200855.app_private.tables.user_email_secrets-up.sql
@@ -30,8 +30,6 @@ comment on function app_private.tg_user_email_secrets__insert_with_user_email() 
   E'Ensures that every user_email record has an associated user_email_secret record.';
 
 create function app_private.tg_send_verification_email_for_user_email() returns trigger as $$
-declare
-  v_verification_token text;
 begin
   -- Trigger email send
   perform graphile_worker.add_job(

--- a/db/migrations/20181102_200855.app_private.tables.user_email_secrets-up.sql
+++ b/db/migrations/20181102_200855.app_private.tables.user_email_secrets-up.sql
@@ -1,11 +1,14 @@
 create table app_private.user_email_secrets (
   user_email_id int primary key references app_public.user_emails on delete cascade,
   verification_token text,
+  verification_email_sent_at timestamptz,
   password_reset_email_sent_at timestamptz
 );
 alter table app_private.user_email_secrets enable row level security;
 comment on table app_private.user_email_secrets is
   E'The contents of this table should never be visible to the user. Contains data mostly related to email verification and avoiding spamming users.';
+comment on column app_private.user_email_secrets.verification_email_sent_at is
+  E'We store the time the last verification email was sent to this email to prevent the email getting flooded.';
 comment on column app_private.user_email_secrets.password_reset_email_sent_at is
   E'We store the time the last password reset was sent to this email to prevent the email getting flooded.';
 create function app_private.tg_user_email_secrets__insert_with_user_email() returns trigger as $$
@@ -25,3 +28,24 @@ create trigger _500_insert_secrets
   execute procedure app_private.tg_user_email_secrets__insert_with_user_email();
 comment on function app_private.tg_user_email_secrets__insert_with_user_email() is
   E'Ensures that every user_email record has an associated user_email_secret record.';
+
+create function app_private.tg_send_verification_email_for_user_email() returns trigger as $$
+declare
+  v_verification_token text;
+begin
+  -- Trigger email send
+  perform graphile_worker.add_job(
+    'sendVerificationEmailForUserEmail',
+    json_build_object(
+      'id', NEW.id
+    )
+  );
+  return NEW;
+end;
+$$ language plpgsql volatile set search_path from current;
+create trigger _900_send_verification_email
+  after insert on app_public.user_emails
+  for each row when (NEW.is_verified is false)
+  execute function app_private.tg_send_verification_email_for_user_email();
+comment on function app_private.tg_send_verification_email_for_user_email() is
+  E'Enqueue a job to send a verification email for unverified user email addresses.';

--- a/db/migrations/20181102_201447.app_public.functions.forgot_password-up.sql
+++ b/db/migrations/20181102_201447.app_public.functions.forgot_password-up.sql
@@ -48,7 +48,16 @@ begin
     set password_reset_email_sent_at = now()
     where user_email_id = v_user_email.id;
 
-    -- TODO: Trigger email send
+    -- Trigger email send
+    perform graphile_worker.add_job(
+      'sendEmail',
+      json_build_object(
+        'to', v_user_email.email::text,
+        'subject', 'reset password',
+        'text', format('Token: %s', v_reset_token)
+      )
+    );
+
     return true;
 
   end if;

--- a/db/migrations/20181102_201934.app_public.functions.reset_password-up.sql
+++ b/db/migrations/20181102_201934.app_public.functions.reset_password-up.sql
@@ -1,6 +1,7 @@
-create function app_public.reset_password(user_id int, reset_token text, new_password text) returns app_public.users as $$
+create function app_public.reset_password(user_id int, token text, new_password text) returns app_public.users as $$
 declare
   v_user app_public.users;
+  v_user_email app_public.user_emails;
   v_user_secret app_private.user_secrets;
   v_reset_max_duration interval = interval '3 days';
 begin
@@ -25,7 +26,7 @@ begin
     end if;
 
     -- Not too many reset attempts, let's check the token
-    if v_user_secret.reset_password_token = reset_token then
+    if v_user_secret.reset_password_token = token then
       -- Excellent - they're legit; let's reset the password as requested
       update app_private.user_secrets
       set
@@ -33,10 +34,30 @@ begin
         password_attempts = 0,
         first_failed_password_attempt = null,
         reset_password_token = null,
-        reset_password_token_generated = null,
+        reset_password_token_generated_at = null,
         reset_password_attempts = 0,
         first_failed_reset_password_attempt = null
       where user_secrets.user_id = v_user.id;
+
+      -- Notify that password has been reset
+      select * into v_user_email
+      from app_public.user_emails
+      where user_emails.user_id = reset_password.user_id
+      and is_verified = true
+      order by created_at
+      limit 1;
+
+      if v_user_email is not NULL then
+        perform graphile_worker.add_job(
+          'sendEmail',
+          json_build_object(
+            'to', v_user_email.email,
+            'subject', 'Your password has been changed',
+            'text', 'Your password has been changed. If you didn''t do this, please contact support immediately.'
+          )
+        );
+      end if;
+
       return v_user;
     else
       -- Wrong token, bump all the attempt tracking figures
@@ -45,14 +66,14 @@ begin
         reset_password_attempts = (case when first_failed_reset_password_attempt is null or first_failed_reset_password_attempt < now() - v_reset_max_duration then 1 else reset_password_attempts + 1 end),
         first_failed_reset_password_attempt = (case when first_failed_reset_password_attempt is null or first_failed_reset_password_attempt < now() - v_reset_max_duration then now() else first_failed_reset_password_attempt end)
       where user_secrets.user_id = v_user.id;
-      return null;
+      raise exception 'Invalid token' using errcode='INVLD';
     end if;
   else
     -- No user with that id was found
-    return null;
+    raise exception 'Invalid user ID' using errcode='INVLD';
   end if;
 end;
 $$ language plpgsql strict volatile security definer set search_path from current;
 
-comment on function app_public.reset_password(user_id int, reset_token text, new_password text) is
+comment on function app_public.reset_password(user_id int, token text, new_password text) is
   E'After triggering forgotPassword, you''ll be sent a reset token. Combine this with your user ID and a new password to reset your password.';

--- a/db/migrations/20190713_000000.app_public.functions.verify_user_email-down.sql
+++ b/db/migrations/20190713_000000.app_public.functions.verify_user_email-down.sql
@@ -1,0 +1,1 @@
+drop function app_public.verify_user_email(token text);

--- a/db/migrations/20190713_000000.app_public.functions.verify_user_email-up.sql
+++ b/db/migrations/20190713_000000.app_public.functions.verify_user_email-up.sql
@@ -1,0 +1,25 @@
+create function app_public.verify_user_email(token text) returns app_public.user_emails as $$
+declare
+  v_user_email app_public.user_emails;
+  v_max_duration interval = interval '7 days';
+begin
+  UPDATE app_public.user_emails
+  SET is_verified = true
+  WHERE id = (
+    SELECT user_email_id
+    FROM app_private.user_email_secrets
+    WHERE user_email_secrets.verification_token = token
+    AND user_email_secrets.verification_email_sent_at > now() - v_max_duration
+  )
+  RETURNING * INTO v_user_email;
+
+  if v_user_email is NULL THEN
+    raise exception 'verification token is invalid or expired' using errcode='INVALID';
+  end if;
+
+  return v_user_email;
+end;
+$$ language plpgsql strict security definer volatile set search_path from current;
+
+comment on function app_public.verify_user_email(token text) is
+  E'@resultFieldName userEmail\nAfter you add an email address, you will receive an email with a verification token. Give us the verification token to mark that email as verified!';

--- a/db/migrations/20190713_000000.app_public.functions.verify_user_email-up.sql
+++ b/db/migrations/20190713_000000.app_public.functions.verify_user_email-up.sql
@@ -14,7 +14,7 @@ begin
   RETURNING * INTO v_user_email;
 
   if v_user_email is NULL THEN
-    raise exception 'verification token is invalid or expired' using errcode='INVALID';
+    raise exception 'verification token is invalid or expired' using errcode='INVLD';
   end if;
 
   return v_user_email;

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "postcss-safe-parser": "^4.0.1",
     "postgraphile": "^4.4.0",
     "prettier": "^1.17.0",
+    "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-apollo": "^2.5.5",
     "react-app-polyfill": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "server:dev": "cd server && nodemon",
     "client:dev": "cd client && BROWSER=none PORT=\"$CLIENT_PORT\" npm run start",
     "start": ". ./scripts/source-env && concurrently --kill-others --names server,client 'npm run server:dev' 'npm run client:dev'",
+    "worker": ". ./scripts/source-env && graphile-worker",
     "test": "jest"
   },
   "repository": {
@@ -47,6 +48,7 @@
     "@graphile-contrib/pg-simplify-inflector": "^5.0.0-beta.1",
     "@graphile/pg-pubsub": "^4.4.0",
     "@graphile/pro": "^0.7.0",
+    "@sendgrid/mail": "^6.4.0",
     "@svgr/webpack": "^4.2.0",
     "apollo-cache-inmemory": "^1.5.1",
     "apollo-client": "^2.5.1",
@@ -84,6 +86,7 @@
     "file-loader": "^3.0.1",
     "fs-extra": "^7.0.1",
     "graphile-utils": "^4.4.0",
+    "graphile-worker": "^0.1.0-alpha.0",
     "graphql": "^14.2.1",
     "graphql-tag": "^2.10.1",
     "html-webpack-plugin": "^4.0.0-alpha.2",

--- a/scripts/setup
+++ b/scripts/setup
@@ -89,6 +89,12 @@ export CLIENT_PORT=5679
 export ROOT_DOMAIN="localhost:\$PORT"
 export ROOT_URL="http://\$ROOT_DOMAIN"
 
+# To send email with SendGrid, sign up on https://sendgrid.com/ and create
+# an API token, then paste it here. You can also customize the default
+# "from" address for outgoing email.
+export SENDGRID_API_KEY=""
+export EMAIL_DEFAULT_FROM="postgraphile@example.com"
+
 # To enable login with GitHub, create a GitHub application by visiting
 # https://github.com/settings/applications/new and then enter the Client
 # ID/Secret below

--- a/server/plugins/authentication.js
+++ b/server/plugins/authentication.js
@@ -23,18 +23,9 @@ const PassportLoginPlugin = makeExtendSchemaPlugin(build => ({
       user: User! @pgField
     }
 
-    input VerifyUserEmailInput {
-      token: String!
-    }
-
-    type VerifyUserEmailPayload {
-      userEmail: UserEmail! @pgField
-    }
-
     extend type Mutation {
       register(input: RegisterInput!): RegisterPayload
       login(input: LoginInput!): LoginPayload
-      verifyUserEmail(input: VerifyUserEmailInput!): VerifyUserEmailPayload
     }
   `,
   resolvers: {
@@ -160,47 +151,6 @@ const PassportLoginPlugin = makeExtendSchemaPlugin(build => ({
           console.error(e);
           throw e;
         }
-      },
-
-      async verifyUserEmail(
-        mutation,
-        args,
-        context,
-        resolveInfo,
-        { selectGraphQLResultFromTable }
-      ) {
-        const { token } = args.input;
-        const { rootPgPool } = context;
-        const updateResult = await rootPgPool.query(
-          `
-          UPDATE app_public.user_emails
-          SET is_verified = true
-          WHERE id = (
-            SELECT user_email_id
-            FROM app_private.user_email_secrets
-            WHERE verification_token = $1
-            AND verification_email_sent_at > now() - '7 days'::interval
-          )
-          RETURNING id
-          `,
-          [token]
-        );
-        if (updateResult.rowCount === 0) {
-          throw new Error("Invalid token");
-        }
-        const userEmailId = updateResult.rows[0].id;
-        const sql = build.pgSql;
-        const [row] = await selectGraphQLResultFromTable(
-          sql.fragment`app_public.user_emails`,
-          (tableAlias, sqlBuilder) => {
-            sqlBuilder.where(
-              sql.fragment`${tableAlias}.id = ${sql.value(userEmailId)}`
-            );
-          }
-        );
-        return {
-          data: row,
-        };
       },
     },
   },

--- a/tasks/sendEmail.js
+++ b/tasks/sendEmail.js
@@ -1,0 +1,13 @@
+const sgMail = require("@sendgrid/mail");
+
+module.exports = async ({ from, to, subject, text, html }) => {
+  const { SENDGRID_API_KEY, EMAIL_DEFAULT_FROM } = process.env;
+  if (!SENDGRID_API_KEY) {
+    throw new Error("Missing required environment variable: SENDGRID_API_KEY");
+  }
+  sgMail.setApiKey(SENDGRID_API_KEY);
+
+  return sgMail
+    .send({ from: from || EMAIL_DEFAULT_FROM, to, subject, text, html })
+    .catch(err => console.error(err));
+};

--- a/tasks/sendPasswordResetEmail.js
+++ b/tasks/sendPasswordResetEmail.js
@@ -1,0 +1,55 @@
+const sendEmail = require("./sendEmail");
+
+const minDurationBetweenEmails = 60 * 30; // 30 minutes
+
+module.exports = async ({ id }, { withPgClient }) => {
+  const { ROOT_URL } = process.env;
+  if (!ROOT_URL) {
+    throw new Error("Missing required environment variable: ROOT_URL");
+  }
+  return withPgClient(async pgClient => {
+    const result = await pgClient.query(
+      `
+      SELECT
+        ue.user_id as uid,
+        ue.email as email,
+        us.reset_password_token as token,
+        ues.password_reset_email_sent_at as sent_at
+      FROM app_public.user_emails AS ue
+        JOIN app_private.user_email_secrets AS ues
+        ON ue.id = ues.user_email_id
+        JOIN app_private.user_secrets AS us
+        ON us.user_id = ue.user_id
+      WHERE ue.id = $1
+      `,
+      [id]
+    );
+    if (result.rowCount === 0) {
+      throw new Error(`Could not find user_email ${id}`);
+    }
+
+    const { uid, email, token, sent_at: sentAt } = result.rows[0];
+    if (sentAt && new Date() - sentAt < minDurationBetweenEmails) {
+      // We're sending emails too quickly.
+      // It would be semantically correct to throw an error here,
+      // but if we do that, this task will be rescheduled for a future time,
+      // which is not what we want. Instead, we will just return a value,
+      // which will mark this task as successfully executed.
+      return "Error: sending emails too quickly";
+    }
+
+    await sendEmail({
+      to: email,
+      subject: "You requested a password reset",
+      text: `${ROOT_URL}/reset-password/${uid}/${token}`,
+    });
+    await pgClient.query(
+      `
+      UPDATE app_private.user_email_secrets AS ues
+      SET password_reset_email_sent_at = now()
+      WHERE ues.user_email_id = $1
+      `,
+      [id]
+    );
+  });
+};

--- a/tasks/sendVerificationEmailForUserEmail.js
+++ b/tasks/sendVerificationEmailForUserEmail.js
@@ -1,0 +1,44 @@
+const sendEmail = require("./sendEmail");
+
+module.exports = async ({ id }, { withPgClient }) => {
+  const { ROOT_URL } = process.env;
+  if (!ROOT_URL) {
+    throw new Error("Missing required environment variable: ROOT_URL");
+  }
+  return withPgClient(async pgClient => {
+    const result = await pgClient.query(
+      `
+      SELECT
+        ue.email AS email,
+        ue.is_verified AS is_verified,
+        ues.verification_token AS token
+      FROM app_public.user_emails AS ue
+        JOIN app_private.user_email_secrets AS ues
+        ON ue.id = ues.user_email_id
+      WHERE ue.id = $1
+      `,
+      [id]
+    );
+    if (result.rowCount === 0) {
+      throw new Error(`Could not find user_email ${id}`);
+    }
+    const { email, token, is_verified: isVerified } = result.rows[0];
+    if (isVerified) {
+      // nothing to do!
+      return;
+    }
+    await sendEmail({
+      to: email,
+      subject: "Please verify your email address",
+      text: `${ROOT_URL}/verify-email/${token}`,
+    });
+    await pgClient.query(
+      `
+      UPDATE app_private.user_email_secrets AS ues
+      SET verification_email_sent_at = now()
+      WHERE ues.user_email_id = $1
+      `,
+      [id]
+    );
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1042,6 +1042,31 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@sendgrid/client@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@sendgrid/client/-/client-6.4.0.tgz#d58df30adea5d7d09e747e2b61f9f859deeda798"
+  integrity sha512-GcO+hKXMQiwN0xMGfPITArlj4Nab1vZsrsRLmsJlcXGZV1V1zQC6XuAWJv6MGDd0hr/jKaXmCJ1XMYkxIRQHFw==
+  dependencies:
+    "@sendgrid/helpers" "^6.4.0"
+    "@types/request" "^2.0.3"
+    request "^2.88.0"
+
+"@sendgrid/helpers@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@sendgrid/helpers/-/helpers-6.4.0.tgz#f9001cbe2f34e2c264d30fcf71aa5b9c3cde49aa"
+  integrity sha512-1dDDXauArHyxwTKFFfWvQpsijmwalyLgwoQJ3FRCssFq1RfqYDgFhRg0Xs3v/IXS2jkKWePSWiPORSR4Sysdpw==
+  dependencies:
+    chalk "^2.0.1"
+    deepmerge "^2.1.1"
+
+"@sendgrid/mail@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@sendgrid/mail/-/mail-6.4.0.tgz#21d022f7fae57dcdc5910eeca5ed318df21e5f51"
+  integrity sha512-pVzbqbxhZ4FUN6iSIksRLtyXRPurrcee1i0noPDStDCLlHVwUR+TofeeKIFWGpIvbbk5UR6S6iV/U5ie8Kdblw==
+  dependencies:
+    "@sendgrid/client" "^6.4.0"
+    "@sendgrid/helpers" "^6.4.0"
+
 "@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz#dadcb6218503532d6884b210e7f3c502caaa44b1"
@@ -1195,6 +1220,19 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/caseless@*":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
+  integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
+
+"@types/chokidar@^1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@types/chokidar/-/chokidar-1.7.5.tgz#1fa78c8803e035bed6d98e6949e514b133b0c9b6"
+  integrity sha512-PDkSRY7KltW3M60hSBlerxI8SFPXsO3AL/aRVsO4Kh9IHRW74Ih75gUuTd/aE4LSSFqypb10UIX3QzOJwBQMGQ==
+  dependencies:
+    "@types/events" "*"
+    "@types/node" "*"
+
 "@types/connect@*":
   version "3.4.32"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.32.tgz#aa0e9616b9435ccad02bc52b5b454ffc2c70ba28"
@@ -1238,6 +1276,13 @@
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
+
+"@types/form-data@*":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-2.2.1.tgz#ee2b3b8eaa11c0938289953606b745b738c54b1e"
+  integrity sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/graphql@^14.0.3", "@types/graphql@^14.0.7":
   version "14.2.0"
@@ -1302,7 +1347,7 @@
   dependencies:
     moment ">=2.14.0"
 
-"@types/pg@^7.4.10", "@types/pg@^7.4.13":
+"@types/pg@^7.4.10", "@types/pg@^7.4.11", "@types/pg@^7.4.13":
   version "7.4.14"
   resolved "https://registry.yarnpkg.com/@types/pg/-/pg-7.4.14.tgz#8235910120e81ca671e0e62b7de77d048b9a22b2"
   integrity sha512-2e4XapP9V/X42IGByC5IHzCzHqLLCNJid8iZBbkk6lkaDMvli8Rk62YE9wjGcLD5Qr5Zaw1ShkQyXy91PI8C0Q==
@@ -1320,6 +1365,16 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
+"@types/request@^2.0.3":
+  version "2.48.1"
+  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.1.tgz#e402d691aa6670fbbff1957b15f1270230ab42fa"
+  integrity sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==
+  dependencies:
+    "@types/caseless" "*"
+    "@types/form-data" "*"
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+
 "@types/serve-static@*":
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.2.tgz#f5ac4d7a6420a99a6a45af4719f4dcd8cd907a48"
@@ -1332,6 +1387,11 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/tough-cookie@*":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-2.3.5.tgz#9da44ed75571999b65c37b60c9b2b88db54c585d"
+  integrity sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==
 
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
@@ -2639,6 +2699,25 @@ chokidar@^2.0.2, chokidar@^2.0.4, chokidar@^2.1.5:
   optionalDependencies:
     fsevents "^1.2.7"
 
+chokidar@^2.1.2:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.6.tgz#b6cad653a929e244ce8a834244164d241fa954c5"
+  integrity sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==
+  dependencies:
+    anymatch "^2.0.0"
+    async-each "^1.0.1"
+    braces "^2.3.2"
+    glob-parent "^3.1.0"
+    inherits "^2.0.3"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    normalize-path "^3.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.2.1"
+    upath "^1.1.1"
+  optionalDependencies:
+    fsevents "^1.2.7"
+
 chownr@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
@@ -2711,6 +2790,15 @@ cliui@^4.0.0:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
+
+cliui@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
+  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
+  dependencies:
+    string-width "^3.1.0"
+    strip-ansi "^5.2.0"
+    wrap-ansi "^5.1.0"
 
 clone-deep@^0.2.4:
   version "0.2.4"
@@ -3499,6 +3587,11 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+deepmerge@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
 
 default-gateway@^4.2.0:
   version "4.2.0"
@@ -4722,6 +4815,11 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
+get-caller-file@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz#b877b49a5c16aefac3655f2ed2ea5b684df8d203"
@@ -4899,6 +4997,21 @@ graphile-utils@^4.4.0:
   dependencies:
     debug ">=2 <3"
     graphql ">=0.9 <0.14 || ^14.0.2"
+
+graphile-worker@^0.1.0-alpha.0:
+  version "0.1.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/graphile-worker/-/graphile-worker-0.1.0-alpha.0.tgz#0e5e0190d070d49626ebd9843ed7c39c0d0aa561"
+  integrity sha512-CevArmLwNUBHFysSyp5xwLtcTAeD5KCwCvCJ5JIlxhQGJZ/eR6lp060/YQ1QINb+UTfVjN+uyji4BGRmTPA70A==
+  dependencies:
+    "@types/chokidar" "^1.7.5"
+    "@types/debug" "^4.1.2"
+    "@types/pg" "^7.4.11"
+    chokidar "^2.1.2"
+    debug "^4.1.1"
+    pg ">=6.5 <8"
+    pg-connection-string "^2.0.0"
+    tslib "^1.9.3"
+    yargs "^13.2.2"
 
 graphql-config@^2.0.1:
   version "2.2.1"
@@ -7595,7 +7708,7 @@ os-homedir@^1.0.0:
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
 
-os-locale@^3.0.0:
+os-locale@^3.0.0, os-locale@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
   integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
@@ -7943,7 +8056,7 @@ pg-types@~2.0.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-"pg@>=6.1.0 <8", pg@^7.10.0, pg@^7.4.3, pg@^7.8.0, pg@^7.8.1:
+"pg@>=6.1.0 <8", "pg@>=6.5 <8", pg@^7.10.0, pg@^7.4.3, pg@^7.8.0, pg@^7.8.1:
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/pg/-/pg-7.11.0.tgz#a8b9ae9cf19199b7952b72957573d0a9c5e67c0c"
   integrity sha512-YO4V7vCmEMGoF390LJaFaohWNKaA2ayoQOEZmiHVcAUF+YsRThpf/TaKCgSvsSE7cDm37Q/Cy3Gz41xiX/XjTw==
@@ -9421,7 +9534,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.87.0:
+request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -10184,7 +10297,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^3.0.0:
+string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
   integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
@@ -10216,7 +10329,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-strip-ansi@5.2.0, strip-ansi@^5.0.0, strip-ansi@^5.1.0:
+strip-ansi@5.2.0, strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -11440,6 +11553,15 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
+wrap-ansi@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+  dependencies:
+    ansi-styles "^3.2.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -11527,6 +11649,14 @@ yargs-parser@^11.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^13.1.0:
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
+  integrity sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs@12.0.5, yargs@^12.0.1, yargs@^12.0.2:
   version "12.0.5"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
@@ -11544,6 +11674,23 @@ yargs@12.0.5, yargs@^12.0.1, yargs@^12.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yargs@^13.2.2:
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.2.4.tgz#0b562b794016eb9651b98bd37acf364aa5d6dc83"
+  integrity sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==
+  dependencies:
+    cliui "^5.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    os-locale "^3.1.0"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.0"
 
 zen-observable-ts@^0.8.18:
   version "0.8.18"


### PR DESCRIPTION
This pull request adds support for verifying a user email address using the standard three-step flow:

1. generate a secret token for the email address
2. send an email to the email address with a link that embeds the token
3. when the user clicks on the link, mark the email as verified

It also adds support for the reset password flow, which is very similar.

This is a rather large pull request: I wish I could make it smaller! Here is a list of some of the changes & improvements that this pull request makes:

* Replaces custom task queue system with [graphile-worker](https://github.com/graphile/worker)
* Creates a registration form on the client side (#18)
* Fixes the `GraphQLRoute` component to properly proxy the `match`, `location`, and `history` objects from React Router
* Uses the `update` property on React Apollo's `Mutation` components to properly update the client-side cache on login
* Integrate [SendGrid](https://sendgrid.com/) for sending email